### PR TITLE
removed pylab reference on some scripts

### DIFF
--- a/README.html
+++ b/README.html
@@ -1091,8 +1091,8 @@ community of users and developpers. Here are some links of interest:</p>
 <p>The code is fairly well documented and you can quickly access a specific
 command from within a python session:</p>
 <pre class="literal-block">
-&gt;&gt;&gt; from pylab import *
-&gt;&gt;&gt; help(plot)
+&gt;&gt;&gt; import matplotlib.pyplot as plt
+&gt;&gt;&gt; help(plt)
 Help on function plot in module matplotlib.pyplot:
 
 plot(*args, **kwargs)

--- a/README.rst
+++ b/README.rst
@@ -1285,8 +1285,8 @@ command from within a python session:
 
 ::
 
-   >>> from pylab import *
-   >>> help(plot)
+   >>> import matplotlib.pyplot as plt
+   >>> help(plt)
    Help on function plot in module matplotlib.pyplot:
 
    plot(*args, **kwargs)

--- a/scripts/aliased.py
+++ b/scripts/aliased.py
@@ -1,16 +1,16 @@
-from pylab import *
+import matplotlib.pyplot as plt
 
 size = 128,16
 dpi = 72.0
 figsize= size[0]/float(dpi),size[1]/float(dpi)
-fig = figure(figsize=figsize, dpi=dpi)
+fig = plt.figure(figsize=figsize, dpi=dpi)
 fig.patch.set_alpha(0)
-axes([0,0,1,1], frameon=False)
+plt.axes([0,0,1,1], frameon=False)
 
-rcParams['text.antialiased'] = False
-text(0.5,0.5,"Aliased",ha='center',va='center')
+plt.rcParams['text.antialiased'] = False
+plt.text(0.5,0.5,"Aliased",ha='center',va='center')
 
 plt.xlim(0,1),plt.ylim(0,1),
 plt.xticks([]),plt.yticks([])
 
-savefig('../figures/aliased.png', dpi=dpi)
+plt.savefig('../figures/aliased.png', dpi=dpi)

--- a/scripts/alpha.py
+++ b/scripts/alpha.py
@@ -1,15 +1,15 @@
-from pylab import *
+import matplotlib.pyplot as plt
 
 size = 256,16
 dpi = 72.0
 figsize= size[0]/float(dpi),size[1]/float(dpi)
-fig = figure(figsize=figsize, dpi=dpi)
+fig = plt.figure(figsize=figsize, dpi=dpi)
 fig.patch.set_alpha(0)
-axes([0,0.1,1,.8], frameon=False)
+plt.axes([0,0.1,1,.8], frameon=False)
 
 for i in range(1,11):
     plt.axvline(i, linewidth=1, color='blue',alpha=.25+.75*i/10.)
 
-xlim(0,11)
-xticks([]),yticks([])
-savefig('../figures/alpha.png', dpi=dpi)
+plt.xlim(0,11)
+plt.xticks([]), plt.yticks([])
+plt.savefig('../figures/alpha.png', dpi=dpi)

--- a/scripts/antialiased.py
+++ b/scripts/antialiased.py
@@ -1,16 +1,16 @@
-from pylab import *
+import matplotlib.pyplot as plt
 
 size = 128,16
 dpi = 72.0
 figsize= size[0]/float(dpi),size[1]/float(dpi)
-fig = figure(figsize=figsize, dpi=dpi)
+fig = plt.figure(figsize=figsize, dpi=dpi)
 fig.patch.set_alpha(0)
-axes([0,0,1,1], frameon=False)
+plt.axes([0,0,1,1], frameon=False)
 
-rcParams['text.antialiased'] = True
-text(0.5,0.5,"Anti-aliased",ha='center',va='center')
+plt.rcParams['text.antialiased'] = True
+plt.text(0.5,0.5,"Anti-aliased",ha='center',va='center')
 
 plt.xlim(0,1),plt.ylim(0,1),
 plt.xticks([]),plt.yticks([])
 
-savefig('../figures/antialiased.png', dpi=dpi)
+plt.savefig('../figures/antialiased.png', dpi=dpi)

--- a/scripts/axes-2.py
+++ b/scripts/axes-2.py
@@ -1,20 +1,20 @@
-from pylab import *
+import matplotlib.pyplot as plt
 
-axes([0.1,0.1,.5,.5])
-xticks([]), yticks([])
-text(0.1,0.1, 'axes([0.1,0.1,.5,.5])',ha='left',va='center',size=16,alpha=.5)
+plt.axes([0.1,0.1,.5,.5])
+plt.xticks([]), plt.yticks([])
+plt.text(0.1,0.1, 'axes([0.1,0.1,.5,.5])',ha='left',va='center',size=16,alpha=.5)
 
-axes([0.2,0.2,.5,.5])
-xticks([]), yticks([])
-text(0.1,0.1, 'axes([0.2,0.2,.5,.5])',ha='left',va='center',size=16,alpha=.5)
+plt.axes([0.2,0.2,.5,.5])
+plt.xticks([]), plt.yticks([])
+plt.text(0.1,0.1, 'axes([0.2,0.2,.5,.5])',ha='left',va='center',size=16,alpha=.5)
 
-axes([0.3,0.3,.5,.5])
-xticks([]), yticks([])
-text(0.1,0.1, 'axes([0.3,0.3,.5,.5])',ha='left',va='center',size=16,alpha=.5)
+plt.axes([0.3,0.3,.5,.5])
+plt.xticks([]), plt.yticks([])
+plt.text(0.1,0.1, 'axes([0.3,0.3,.5,.5])',ha='left',va='center',size=16,alpha=.5)
 
-axes([0.4,0.4,.5,.5])
-xticks([]), yticks([])
-text(0.1,0.1, 'axes([0.4,0.4,.5,.5])',ha='left',va='center',size=16,alpha=.5)
+plt.axes([0.4,0.4,.5,.5])
+plt.xticks([]), plt.yticks([])
+plt.text(0.1,0.1, 'axes([0.4,0.4,.5,.5])',ha='left',va='center',size=16,alpha=.5)
 
 # plt.savefig("../figures/axes-2.png",dpi=64)
-show()
+plt.show()

--- a/scripts/axes.py
+++ b/scripts/axes.py
@@ -1,12 +1,12 @@
-from pylab import *
+import matplotlib.pyplot as plt
 
-axes([0.1,0.1,.8,.8])
-xticks([]), yticks([])
-text(0.6,0.6, 'axes([0.1,0.1,.8,.8])',ha='center',va='center',size=20,alpha=.5)
+plt.axes([0.1,0.1,.8,.8])
+plt.xticks([]), plt.yticks([])
+plt.text(0.6,0.6, 'axes([0.1,0.1,.8,.8])',ha='center',va='center',size=20,alpha=.5)
 
-axes([0.2,0.2,.3,.3])
-xticks([]), yticks([])
-text(0.5,0.5, 'axes([0.2,0.2,.3,.3])',ha='center',va='center',size=16,alpha=.5)
+plt.axes([0.2,0.2,.3,.3])
+plt.xticks([]), plt.yticks([])
+plt.text(0.5,0.5, 'axes([0.2,0.2,.3,.3])',ha='center',va='center',size=16,alpha=.5)
 
 plt.savefig("../figures/axes.png",dpi=64)
-show()
+plt.show()()

--- a/scripts/color.py
+++ b/scripts/color.py
@@ -1,14 +1,14 @@
-from pylab import *
+import matplotlib.pyplot as plt
 
 size = 256,16
 dpi = 72.0
 figsize= size[0]/float(dpi),size[1]/float(dpi)
-fig = figure(figsize=figsize, dpi=dpi)
+fig = plt.figure(figsize=figsize, dpi=dpi)
 fig.patch.set_alpha(0)
-axes([0,0.1,1,.8], frameon=False)
+plt.axes([0,0.1,1,.8], frameon=False)
 
 for i in range(1,11):
-    plot( [i,i], [0,1], lw=1.5 )
-xlim(0,11)
-xticks([]),yticks([])
-savefig('../figures/color.png', dpi=dpi)
+    plt.plot( [i,i], [0,1], lw=1.5 )
+plt.xlim(0,11)
+plt.xticks([]), plt.yticks([])
+plt.savefig('../figures/color.png', dpi=dpi)

--- a/scripts/colormaps.py
+++ b/scripts/colormaps.py
@@ -1,4 +1,5 @@
-from pylab import *
+import matplotlib.pyplot as plt
+import numpy as np
 
 def colormap(cmap,filename):
     n = 512
@@ -8,14 +9,14 @@ def colormap(cmap,filename):
     figsize= size[0]/float(dpi),size[1]/float(dpi)
     fig = plt.figure(figsize=figsize, dpi=dpi)
     fig.patch.set_alpha(0)
-    axes([0.,0.,1.,1.], frameon=False)
-    xticks([]), yticks([])
-    imshow(Z,aspect='auto',cmap=cmap,origin="lower")
-    savefig( "../figures/cmap-%s.png" % filename, dpi=dpi )
+    plt.axes([0.,0.,1.,1.], frameon=False)
+    plt.xticks([]), plt.yticks([])
+    plt.imshow(Z,aspect='auto',cmap=cmap,origin="lower")
+    plt.savefig( "../figures/cmap-%s.png" % filename, dpi=dpi )
 
 
 
-cmaps = [m for m in cm.datad if not m.endswith("_r")]
+cmaps = [m for m in plt.cm.datad if not m.endswith("_r")]
 cmaps.sort()
 
 #print """

--- a/scripts/dash_capstyle.py
+++ b/scripts/dash_capstyle.py
@@ -1,20 +1,21 @@
-from pylab import *
+import matplotlib.pyplot as plt
+import numpy as np
 
 size = 256,16
 dpi = 72.0
 figsize= size[0]/float(dpi),size[1]/float(dpi)
-fig = figure(figsize=figsize, dpi=dpi)
+fig = plt.figure(figsize=figsize, dpi=dpi)
 fig.patch.set_alpha(0)
-axes([0,0,1,1], frameon=False)
+plt.axes([0,0,1,1], frameon=False)
 
-plot(np.arange(4), np.ones(4), color="blue", dashes=[15,15], linewidth=8, dash_capstyle = 'butt')
+plt.plot(np.arange(4), np.ones(4), color="blue", dashes=[15,15], linewidth=8, dash_capstyle = 'butt')
 
-plot(5+np.arange(4), np.ones(4), color="blue", dashes=[15,15], linewidth=8, dash_capstyle = 'round')
+plt.plot(5+np.arange(4), np.ones(4), color="blue", dashes=[15,15], linewidth=8, dash_capstyle = 'round')
 
-plot(10+np.arange(4), np.ones(4), color="blue", dashes=[15,15], linewidth=8, dash_capstyle = 'projecting')
+plt.plot(10+np.arange(4), np.ones(4), color="blue", dashes=[15,15], linewidth=8, dash_capstyle = 'projecting')
 
-xlim(0,14)
-xticks([]),yticks([])
+plt.xlim(0,14)
+plt.xticks([]), plt.yticks([])
 
-savefig('../figures/dash_capstyle.png', dpi=dpi)
+plt.savefig('../figures/dash_capstyle.png', dpi=dpi)
 #show()

--- a/scripts/dash_joinstyle.py
+++ b/scripts/dash_joinstyle.py
@@ -1,18 +1,19 @@
-from pylab import *
+import matplotlib.pyplot as plt
+import numpy as np
 
 size = 256,16
 dpi = 72.0
 figsize= size[0]/float(dpi),size[1]/float(dpi)
-fig = figure(figsize=figsize, dpi=dpi)
+fig = plt.figure(figsize=figsize, dpi=dpi)
 fig.patch.set_alpha(0)
-axes([0,0,1,1], frameon=False)
+plt.axes([0,0,1,1], frameon=False)
 
-plot(np.arange(3), [0,1,0], color="blue", dashes=[12,5], linewidth=8, dash_joinstyle = 'miter')
-plot(4+np.arange(3), [0,1,0], color="blue", dashes=[12,5], linewidth=8, dash_joinstyle = 'bevel')
-plot(8+np.arange(3), [0,1,0], color="blue", dashes=[12,5], linewidth=8, dash_joinstyle = 'round')
+plt.plot(np.arange(3), [0,1,0], color="blue", dashes=[12,5], linewidth=8, dash_joinstyle = 'miter')
+plt.plot(4+np.arange(3), [0,1,0], color="blue", dashes=[12,5], linewidth=8, dash_joinstyle = 'bevel')
+plt.plot(8+np.arange(3), [0,1,0], color="blue", dashes=[12,5], linewidth=8, dash_joinstyle = 'round')
 
-xlim(0,12), ylim(-1,2)
-xticks([]),yticks([])
+plt.xlim(0,12), plt.ylim(-1,2)
+plt.xticks([]), plt.yticks([])
 
-savefig('../figures/dash_joinstyle.png', dpi=dpi)
+plt.savefig('../figures/dash_joinstyle.png', dpi=dpi)
 #show()

--- a/scripts/exercice_4-bis.py
+++ b/scripts/exercice_4-bis.py
@@ -1,17 +1,18 @@
-from pylab import *
+import matplotlib.pyplot as plt
+import numpy as np
 
-figure(figsize=(8,5), dpi=80)
-subplot(111)
+plt.figure(figsize=(8,5), dpi=80)
+plt.subplot(111)
 
 X = np.linspace(-np.pi, np.pi, 256,endpoint=True)
 C,S = np.cos(X), np.sin(X)
 
-plot(X, C, color="blue", linewidth=2.5, linestyle="-")
-plot(X+.1, C, color="blue", linewidth=2.5, linestyle="-",alpha=.15)
-plot(X, S, color="red", linewidth=2.5, linestyle="-")
+plt.plot(X, C, color="blue", linewidth=2.5, linestyle="-")
+plt.plot(X+.1, C, color="blue", linewidth=2.5, linestyle="-",alpha=.15)
+plt.plot(X, S, color="red", linewidth=2.5, linestyle="-")
 
-xlim(X.min()*1.1, X.max()*1.1)
-ylim(C.min()*1.1,C.max()*1.1)
+plt.xlim(X.min()*1.1, X.max()*1.1)
+plt.ylim(C.min()*1.1,C.max()*1.1)
 
 # savefig("../figures/exercice_4.png",dpi=72)
-show()
+plt.show()()


### PR DESCRIPTION
Hi Nicolas,

I removed on some scripts the reference to pylab and changed it to pyplot. Some other cases (not in this PR) can't be upgraded because bbox complains if a width is passed. There I don't know how to fix it. An example is polar.py:21.

Cheers,
Joshy