### PR TITLE
Correct colormap typo of 'Diverging' and 'Sequential' 

### DIFF
--- a/README.html
+++ b/README.html
@@ -1664,7 +1664,7 @@ colormaps</a>.</p>
 </table>
 </div>
 <div class="section" id="sequential">
-<h3>Sequential</h3>
+<h3>Diverging</h3>
 <table border="1" class="docutils">
 <colgroup>
 <col width="30%" />
@@ -1716,7 +1716,7 @@ colormaps</a>.</p>
 </table>
 </div>
 <div class="section" id="diverging">
-<h3>Diverging</h3>
+<h3>Sequential</h3>
 <table border="1" class="docutils">
 <colgroup>
 <col width="30%" />

--- a/README.rst
+++ b/README.rst
@@ -1754,7 +1754,7 @@ GIST
      - .. image:: figures/cmap-gist_yarg.png
 
 
-Sequential
+Diverging
 ..........
 
 .. list-table::
@@ -1793,7 +1793,7 @@ Sequential
 
 
 
-Diverging
+Sequential
 .........
 
 .. list-table::


### PR DESCRIPTION
Just swap the two headings in both README.rst and README.html