### PR TITLE
Update earthquakes example

### DIFF
--- a/README.html
+++ b/README.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.12: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
 <title>Matplotlib tutorial</title>
 <link rel="stylesheet" href="dana.css" type="text/css" />
 </head>
@@ -12,17 +12,17 @@
 <h1 class="title">Matplotlib tutorial</h1>
 <h2 class="subtitle" id="nicolas-p-rougier">Nicolas P. Rougier</h2>
 
-<a class="reference external image-reference" href="http://dx.doi.org/10.5281/zenodo.28747"><img alt="https://zenodo.org/badge/doi/10.5281/zenodo.28747.png" src="https://zenodo.org/badge/doi/10.5281/zenodo.28747.png" /></a>
+<a class="reference external image-reference" href="http://dx.doi.org/10.5281/zenodo.28747"><object data="https://zenodo.org/badge/doi/10.5281/zenodo.28747.svg" type="image/svg+xml">https://zenodo.org/badge/doi/10.5281/zenodo.28747.svg</object></a>
 <div class="contents local topic" id="table-of-contents">
-<p class="topic-title first">Table of Contents</p>
+<p class="topic-title">Table of Contents</p>
 <ul class="simple">
-<li><a class="reference internal" href="#introduction" id="id4">Introduction</a></li>
-<li><a class="reference internal" href="#simple-plot" id="id5">Simple plot</a></li>
-<li><a class="reference internal" href="#figures-subplots-axes-and-ticks" id="id6">Figures, Subplots, Axes and Ticks</a></li>
-<li><a class="reference internal" href="#animation" id="id7">Animation</a></li>
-<li><a class="reference internal" href="#other-types-of-plots" id="id8">Other Types of Plots</a></li>
-<li><a class="reference internal" href="#beyond-this-tutorial" id="id9">Beyond this tutorial</a></li>
-<li><a class="reference internal" href="#quick-references" id="id10">Quick references</a></li>
+<li><a class="reference internal" href="#introduction" id="id5">Introduction</a></li>
+<li><a class="reference internal" href="#simple-plot" id="id6">Simple plot</a></li>
+<li><a class="reference internal" href="#figures-subplots-axes-and-ticks" id="id7">Figures, Subplots, Axes and Ticks</a></li>
+<li><a class="reference internal" href="#animation" id="id8">Animation</a></li>
+<li><a class="reference internal" href="#other-types-of-plots" id="id9">Other Types of Plots</a></li>
+<li><a class="reference internal" href="#beyond-this-tutorial" id="id10">Beyond this tutorial</a></li>
+<li><a class="reference internal" href="#quick-references" id="id11">Quick references</a></li>
 </ul>
 </div>
 <p>Sources are available from
@@ -30,15 +30,14 @@
 <p>All code and material is licensed under a <a class="reference external" href="http://creativecommons.org/licenses/by-sa/4.0">Creative Commons
 Attribution-ShareAlike 4.0</a>.</p>
 <p>You can test your installation before the tutorial using the <a class="reference external" href="scripts/check-installation.py">check-installation.py</a> script.</p>
-<p>Tutorial can be read at <a class="reference external" href="http://www.labri.fr/perso/nrougier/teaching/matplotlib/matplotlib.html">http://www.labri.fr/perso/nrougier/teaching/matplotlib/matplotlib.html</a></p>
 <p>See also:</p>
 <ul class="simple">
-<li><a class="reference external" href="http://www.labri.fr/perso/nrougier/teaching/numpy/numpy.html">Numpy tutorial</a></li>
-<li><a class="reference external" href="http://www.labri.fr/perso/nrougier/teaching/numpy.100/index.html">100 Numpy exercices</a></li>
+<li><a class="reference external" href="http://www.labri.fr/perso/nrougier/from-python-to-numpy/">From Python to Numpy</a></li>
+<li><a class="reference external" href="https://github.com/rougier/numpy-100">100 Numpy exercices</a></li>
 <li><a class="reference external" href="http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1003833">Ten simple rules for better figures</a></li>
 </ul>
 <div class="section" id="introduction">
-<h1><a class="toc-backref" href="#id4">Introduction</a></h1>
+<h1><a class="toc-backref" href="#id5">Introduction</a></h1>
 <p>matplotlib is probably the single most used Python package for 2D-graphics. It
 provides both a very quick way to visualize data from Python and
 publication-quality figures in many formats.  We are going to explore
@@ -47,7 +46,7 @@ matplotlib in interactive mode covering most common cases.</p>
 <h2>IPython</h2>
 <p><a class="reference external" href="http://ipython.org/">IPython</a> is an enhanced interactive Python shell that
 has lots of interesting features including named inputs and outputs, access to
-shell commands, improved debugging and many more. It allows
+shell commands, improved debugging and much more. It allows
 interactive matplotlib sessions that have Matlab/Mathematica-like functionality.</p>
 </div>
 <div class="section" id="pyplot">
@@ -59,18 +58,18 @@ arguments. Important commands are explained with interactive examples.</p>
 </div>
 </div>
 <div class="section" id="simple-plot">
-<h1><a class="toc-backref" href="#id5">Simple plot</a></h1>
+<h1><a class="toc-backref" href="#id6">Simple plot</a></h1>
 <p>In this section, we want to draw the cosine and sine functions on the same
 plot. Starting from the default settings, we'll enrich the figure step by step
 to make it nicer.</p>
-<p>First step is to get the data for the sine and cosine functions:</p>
+<p>The first step is to get the data for the sine and cosine functions:</p>
 <pre class="literal-block">
 import numpy as np
 
-X = np.linspace(-np.pi, np.pi, 256,endpoint=True)
-C,S = np.cos(X), np.sin(X)
+X = np.linspace(-np.pi, np.pi, 256, endpoint=True)
+C, S = np.cos(X), np.sin(X)
 </pre>
-<p>X is now a numpy array with 256 values ranging from -π to +π (included). C is
+<p>X is now a NumPy array with 256 values ranging from -π to +π (included). C is
 the cosine (256 values) and S is the sine (256 values).</p>
 <p>To run the example, you can download each of the examples and run it using:</p>
 <pre class="literal-block">
@@ -79,7 +78,7 @@ $ python exercice_1.py
 <p>You can get source for each step by clicking on the corresponding figure.</p>
 <div class="section" id="using-defaults">
 <h2>Using defaults</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/users/pyplot_tutorial.html">plot tutorial</a></li>
@@ -94,10 +93,10 @@ grid properties, text and font properties and so on. While matplotlib defaults
 are rather good in most cases, you may want to modify some properties for
 specific cases.</p>
 <pre class="code python literal-block">
-<span class="keyword namespace">import</span> <span class="name namespace">numpy</span> <span class="keyword namespace">as</span> <span class="name namespace">np</span>
-<span class="keyword namespace">import</span> <span class="name namespace">matplotlib.pyplot</span> <span class="keyword namespace">as</span> <span class="name namespace">plt</span>
+<span class="keyword namespace">import</span> <span class="name namespace">numpy</span> <span class="keyword">as</span> <span class="name namespace">np</span>
+<span class="keyword namespace">import</span> <span class="name namespace">matplotlib.pyplot</span> <span class="keyword">as</span> <span class="name namespace">plt</span>
 
-<span class="name">X</span> <span class="operator">=</span> <span class="name">np</span><span class="operator">.</span><span class="name">linspace</span><span class="punctuation">(</span><span class="operator">-</span><span class="name">np</span><span class="operator">.</span><span class="name">pi</span><span class="punctuation">,</span> <span class="name">np</span><span class="operator">.</span><span class="name">pi</span><span class="punctuation">,</span> <span class="literal number integer">256</span><span class="punctuation">,</span> <span class="name">endpoint</span><span class="operator">=</span><span class="name builtin pseudo">True</span><span class="punctuation">)</span>
+<span class="name">X</span> <span class="operator">=</span> <span class="name">np</span><span class="operator">.</span><span class="name">linspace</span><span class="punctuation">(</span><span class="operator">-</span><span class="name">np</span><span class="operator">.</span><span class="name">pi</span><span class="punctuation">,</span> <span class="name">np</span><span class="operator">.</span><span class="name">pi</span><span class="punctuation">,</span> <span class="literal number integer">256</span><span class="punctuation">,</span> <span class="name">endpoint</span><span class="operator">=</span><span class="keyword constant">True</span><span class="punctuation">)</span>
 <span class="name">C</span><span class="punctuation">,</span><span class="name">S</span> <span class="operator">=</span> <span class="name">np</span><span class="operator">.</span><span class="name">cos</span><span class="punctuation">(</span><span class="name">X</span><span class="punctuation">),</span> <span class="name">np</span><span class="operator">.</span><span class="name">sin</span><span class="punctuation">(</span><span class="name">X</span><span class="punctuation">)</span>
 
 <span class="name">plt</span><span class="operator">.</span><span class="name">plot</span><span class="punctuation">(</span><span class="name">X</span><span class="punctuation">,</span><span class="name">C</span><span class="punctuation">)</span>
@@ -108,7 +107,7 @@ specific cases.</p>
 </div>
 <div class="section" id="instantiating-defaults">
 <h2>Instantiating defaults</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/users/customizing.html">Customizing matplotlib</a></li>
@@ -121,16 +120,16 @@ set to their default values, but now you can interactively play with the values
 to explore their affect (see <a class="reference internal" href="#line-properties">Line properties</a> and <a class="reference internal" href="#line-styles">Line styles</a> below).</p>
 <pre class="code python literal-block">
 <span class="comment single"># Imports</span>
-<span class="keyword namespace">import</span> <span class="name namespace">numpy</span> <span class="keyword namespace">as</span> <span class="name namespace">np</span>
-<span class="keyword namespace">import</span> <span class="name namespace">matplotlib.pyplot</span> <span class="keyword namespace">as</span> <span class="name namespace">plt</span>
+<span class="keyword namespace">import</span> <span class="name namespace">numpy</span> <span class="keyword">as</span> <span class="name namespace">np</span>
+<span class="keyword namespace">import</span> <span class="name namespace">matplotlib.pyplot</span> <span class="keyword">as</span> <span class="name namespace">plt</span>
 
 <span class="comment single"># Create a new figure of size 8x6 points, using 100 dots per inch</span>
-<span class="name">plt</span><span class="operator">.</span><span class="name">figure</span><span class="punctuation">(</span><span class="name">figsize</span><span class="operator">=</span><span class="punctuation">(</span><span class="literal number integer">8</span><span class="punctuation">,</span><span class="literal number integer">6</span><span class="punctuation">),</span> <span class="name">dpi</span><span class="operator">=</span><span class="literal number integer">80</span><span class="punctuation">)</span>
+<span class="name">plt</span><span class="operator">.</span><span class="name">figure</span><span class="punctuation">(</span><span class="name">figsize</span><span class="operator">=</span><span class="punctuation">(</span><span class="literal number integer">8</span><span class="punctuation">,</span><span class="literal number integer">6</span><span class="punctuation">),</span> <span class="name">dpi</span><span class="operator">=</span><span class="literal number integer">100</span><span class="punctuation">)</span>
 
 <span class="comment single"># Create a new subplot from a grid of 1x1</span>
 <span class="name">plt</span><span class="operator">.</span><span class="name">subplot</span><span class="punctuation">(</span><span class="literal number integer">111</span><span class="punctuation">)</span>
 
-<span class="name">X</span> <span class="operator">=</span> <span class="name">np</span><span class="operator">.</span><span class="name">linspace</span><span class="punctuation">(</span><span class="operator">-</span><span class="name">np</span><span class="operator">.</span><span class="name">pi</span><span class="punctuation">,</span> <span class="name">np</span><span class="operator">.</span><span class="name">pi</span><span class="punctuation">,</span> <span class="literal number integer">256</span><span class="punctuation">,</span><span class="name">endpoint</span><span class="operator">=</span><span class="name builtin pseudo">True</span><span class="punctuation">)</span>
+<span class="name">X</span> <span class="operator">=</span> <span class="name">np</span><span class="operator">.</span><span class="name">linspace</span><span class="punctuation">(</span><span class="operator">-</span><span class="name">np</span><span class="operator">.</span><span class="name">pi</span><span class="punctuation">,</span> <span class="name">np</span><span class="operator">.</span><span class="name">pi</span><span class="punctuation">,</span> <span class="literal number integer">256</span><span class="punctuation">,</span><span class="name">endpoint</span><span class="operator">=</span><span class="keyword constant">True</span><span class="punctuation">)</span>
 <span class="name">C</span><span class="punctuation">,</span><span class="name">S</span> <span class="operator">=</span> <span class="name">np</span><span class="operator">.</span><span class="name">cos</span><span class="punctuation">(</span><span class="name">X</span><span class="punctuation">),</span> <span class="name">np</span><span class="operator">.</span><span class="name">sin</span><span class="punctuation">(</span><span class="name">X</span><span class="punctuation">)</span>
 
 <span class="comment single"># Plot cosine using blue color with a continuous line of width 1 (pixels)</span>
@@ -143,13 +142,13 @@ to explore their affect (see <a class="reference internal" href="#line-propertie
 <span class="name">plt</span><span class="operator">.</span><span class="name">xlim</span><span class="punctuation">(</span><span class="operator">-</span><span class="literal number float">4.0</span><span class="punctuation">,</span><span class="literal number float">4.0</span><span class="punctuation">)</span>
 
 <span class="comment single"># Set x ticks</span>
-<span class="name">plt</span><span class="operator">.</span><span class="name">xticks</span><span class="punctuation">(</span><span class="name">np</span><span class="operator">.</span><span class="name">linspace</span><span class="punctuation">(</span><span class="operator">-</span><span class="literal number integer">4</span><span class="punctuation">,</span><span class="literal number integer">4</span><span class="punctuation">,</span><span class="literal number integer">9</span><span class="punctuation">,</span><span class="name">endpoint</span><span class="operator">=</span><span class="name builtin pseudo">True</span><span class="punctuation">))</span>
+<span class="name">plt</span><span class="operator">.</span><span class="name">xticks</span><span class="punctuation">(</span><span class="name">np</span><span class="operator">.</span><span class="name">linspace</span><span class="punctuation">(</span><span class="operator">-</span><span class="literal number integer">4</span><span class="punctuation">,</span><span class="literal number integer">4</span><span class="punctuation">,</span><span class="literal number integer">9</span><span class="punctuation">,</span><span class="name">endpoint</span><span class="operator">=</span><span class="keyword constant">True</span><span class="punctuation">))</span>
 
 <span class="comment single"># Set y limits</span>
 <span class="name">plt</span><span class="operator">.</span><span class="name">ylim</span><span class="punctuation">(</span><span class="operator">-</span><span class="literal number float">1.0</span><span class="punctuation">,</span><span class="literal number float">1.0</span><span class="punctuation">)</span>
 
 <span class="comment single"># Set y ticks</span>
-<span class="name">plt</span><span class="operator">.</span><span class="name">yticks</span><span class="punctuation">(</span><span class="name">np</span><span class="operator">.</span><span class="name">linspace</span><span class="punctuation">(</span><span class="operator">-</span><span class="literal number integer">1</span><span class="punctuation">,</span><span class="literal number integer">1</span><span class="punctuation">,</span><span class="literal number integer">5</span><span class="punctuation">,</span><span class="name">endpoint</span><span class="operator">=</span><span class="name builtin pseudo">True</span><span class="punctuation">))</span>
+<span class="name">plt</span><span class="operator">.</span><span class="name">yticks</span><span class="punctuation">(</span><span class="name">np</span><span class="operator">.</span><span class="name">linspace</span><span class="punctuation">(</span><span class="operator">-</span><span class="literal number integer">1</span><span class="punctuation">,</span><span class="literal number integer">1</span><span class="punctuation">,</span><span class="literal number integer">5</span><span class="punctuation">,</span><span class="name">endpoint</span><span class="operator">=</span><span class="keyword constant">True</span><span class="punctuation">))</span>
 
 <span class="comment single"># Save figure using 72 dots per inch</span>
 <span class="comment single"># savefig(&quot;../figures/exercice_2.png&quot;,dpi=72)</span>
@@ -160,7 +159,7 @@ to explore their affect (see <a class="reference internal" href="#line-propertie
 </div>
 <div class="section" id="changing-colors-and-line-widths">
 <h2>Changing colors and line widths</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/users/pyplot_tutorial.html#controlling-line-properties">Controlling line properties</a></li>
@@ -168,7 +167,7 @@ to explore their affect (see <a class="reference internal" href="#line-propertie
 </ul>
 </div>
 <a class="reference external image-reference" href="scripts/exercice_3.py"><img alt="figures/exercice_3.png" class="align-right" src="figures/exercice_3.png" /></a>
-<p>First step, we want to have the cosine in blue and the sine in red and a
+<p>As a first step, we want to have the cosine in blue and the sine in red and a
 slightly thicker line for both of them. We'll also slightly alter the figure
 size to make it more horizontal.</p>
 <pre class="literal-block">
@@ -181,7 +180,7 @@ plt.plot(X, S, color=&quot;red&quot;,  linewidth=2.5, linestyle=&quot;-&quot;)
 </div>
 <div class="section" id="setting-limits">
 <h2>Setting limits</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.xlim">xlim() command</a></li>
@@ -200,7 +199,7 @@ plt.ylim(C.min()*1.1, C.max()*1.1)
 </div>
 <div class="section" id="setting-ticks">
 <h2>Setting ticks</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.xticks">xticks() command</a></li>
@@ -222,7 +221,7 @@ plt.yticks([-1, 0, +1])
 </div>
 <div class="section" id="setting-tick-labels">
 <h2>Setting tick labels</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/users/index_text.html">Working with text</a></li>
@@ -249,7 +248,7 @@ plt.yticks([-1, 0, +1],
 </div>
 <div class="section" id="moving-spines">
 <h2>Moving spines</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/api/spines_api.html#matplotlib.spines">Spines</a></li>
@@ -278,7 +277,7 @@ ax.spines['left'].set_position(('data',0))
 </div>
 <div class="section" id="adding-a-legend">
 <h2>Adding a legend</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/users/legend_guide.html">Legend guide</a></li>
@@ -301,7 +300,7 @@ plt.legend(loc='upper left', frameon=False)
 </div>
 <div class="section" id="annotate-some-points">
 <h2>Annotate some points</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/users/annotations_guide.html">Annotating axis</a></li>
@@ -309,7 +308,7 @@ plt.legend(loc='upper left', frameon=False)
 </ul>
 </div>
 <a class="reference external image-reference" href="scripts/exercice_9.py"><img alt="figures/exercice_9.png" class="align-right" src="figures/exercice_9.png" /></a>
-<p>Let's annotate some interesting points using the annotate command. We chose the
+<p>Let's annotate some interesting points using the annotate command. We choose the
 2π/3 value and we want to annotate both the sine and the cosine. We'll first
 draw a marker on the curve as well as a straight dotted line. Then, we'll use
 the annotate command to display some text with an arrow.</p>
@@ -337,7 +336,7 @@ plt.annotate(r'$\cos(\frac{2\pi}{3})=-\frac{1}{2}$',
 </div>
 <div class="section" id="devil-is-in-the-details">
 <h2>Devil is in the details</h2>
-<div class="admonition-documentation admonition">
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li><a class="reference external" href="http://matplotlib.sourceforge.net/api/artist_api.html">Artists</a></li>
@@ -359,7 +358,7 @@ for label in ax.get_xticklabels() + ax.get_yticklabels():
 </div>
 </div>
 <div class="section" id="figures-subplots-axes-and-ticks">
-<h1><a class="toc-backref" href="#id6">Figures, Subplots, Axes and Ticks</a></h1>
+<h1><a class="toc-backref" href="#id7">Figures, Subplots, Axes and Ticks</a></h1>
 <p>So far we have used implicit figure and axes creation. This is handy for fast
 plots. We can have more control over the display using figure, subplot, and
 axes explicitly. A figure in matplotlib means the whole window in the user
@@ -418,7 +417,7 @@ determine what the figure looks like:</p>
 <p>The defaults can be specified in the resource file and will be used most of the
 time. Only the number of the figure is frequently changed.</p>
 <p>When you work with the GUI you can close a figure by clicking on the x in the
-upper right corner. But you can close a figure programmatically by calling
+upper right corner. You can also close a figure programmatically by calling
 close. Depending on the argument it closes (1) the current figure (no
 argument), (2) a specific figure (figure number or figure instance as
 argument), or (3) all figures (all as argument).</p>
@@ -448,13 +447,13 @@ so with axes.</p>
 figures. Matplotlib provides a totally configurable system for ticks. There are
 tick locators to specify where ticks should appear and tick formatters to give
 ticks the appearance you want. Major and minor ticks can be located and
-formatted independently from each other. Per default minor ticks are not shown,
+formatted independently from each other. By default minor ticks are not shown,
 i.e. there is only an empty list for them because it is as NullLocator (see
 below).</p>
 <div class="section" id="tick-locators">
 <h3>Tick Locators</h3>
 <p>There are several locators for different kind of requirements:</p>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="22%" />
 <col width="78%" />
@@ -510,13 +509,13 @@ matplotlib.dates.</p>
 </div>
 </div>
 <div class="section" id="animation">
-<h1><a class="toc-backref" href="#id7">Animation</a></h1>
+<h1><a class="toc-backref" href="#id8">Animation</a></h1>
 <p>For quite a long time, animation in matplotlib was not an easy task and was
 done mainly through clever hacks. However, things have started to change since
 version 1.1 and the introduction of tools for creating animation very
 intuitively, with the possibility to save them in all kind of formats (but don't
-expect to be able to run very complex animation at 60 fps though).</p>
-<div class="admonition-documentation admonition">
+expect to be able to run very complex animations at 60 fps though).</p>
+<div class="admonition admonition-documentation">
 <p class="first admonition-title">Documentation</p>
 <ul class="last simple">
 <li>See <a class="reference external" href="http://matplotlib.org/api/animation_api.html">Animation</a></li>
@@ -538,14 +537,14 @@ more visible. At this point, we remove the ring and create a new one.</p>
 <span class="name">fig</span> <span class="operator">=</span> <span class="name">plt</span><span class="operator">.</span><span class="name">figure</span><span class="punctuation">(</span><span class="name">figsize</span><span class="operator">=</span><span class="punctuation">(</span><span class="literal number integer">6</span><span class="punctuation">,</span><span class="literal number integer">6</span><span class="punctuation">),</span> <span class="name">facecolor</span><span class="operator">=</span><span class="literal string single">'white'</span><span class="punctuation">)</span>
 
 <span class="comment single"># New axis over the whole figure, no frame and a 1:1 aspect ratio</span>
-<span class="name">ax</span> <span class="operator">=</span> <span class="name">fig</span><span class="operator">.</span><span class="name">add_axes</span><span class="punctuation">([</span><span class="literal number integer">0</span><span class="punctuation">,</span><span class="literal number integer">0</span><span class="punctuation">,</span><span class="literal number integer">1</span><span class="punctuation">,</span><span class="literal number integer">1</span><span class="punctuation">],</span> <span class="name">frameon</span><span class="operator">=</span><span class="name builtin pseudo">False</span><span class="punctuation">,</span> <span class="name">aspect</span><span class="operator">=</span><span class="literal number integer">1</span><span class="punctuation">)</span>
+<span class="name">ax</span> <span class="operator">=</span> <span class="name">fig</span><span class="operator">.</span><span class="name">add_axes</span><span class="punctuation">([</span><span class="literal number integer">0</span><span class="punctuation">,</span><span class="literal number integer">0</span><span class="punctuation">,</span><span class="literal number integer">1</span><span class="punctuation">,</span><span class="literal number integer">1</span><span class="punctuation">],</span> <span class="name">frameon</span><span class="operator">=</span><span class="keyword constant">False</span><span class="punctuation">,</span> <span class="name">aspect</span><span class="operator">=</span><span class="literal number integer">1</span><span class="punctuation">)</span>
 </pre>
 <p>Next, we need to create several rings. For this, we can use the scatter plot
 object that is generally used to visualize points cloud, but we can also use it
-to draw rings by specifying we don't have a facecolor. We have also to take
-care of initial size and color for each ring such that we have all size between
-a minimum and a maximum size and also to make sure the largest ring is almost
-transparent.</p>
+to draw rings by specifying we don't have a facecolor. We also have to take
+care of initial size and color for each ring such that we have all sizes between
+a minimum and a maximum size. In addition, we need to make sure the largest ring
+is almost transparent.</p>
 <a class="reference external image-reference" href="scripts/rain-static.py"><img alt="figures/rain-static.png" class="align-right" src="figures/rain-static.png" /></a>
 <pre class="code python literal-block">
 <span class="comment single"># Number of ring</span>
@@ -573,10 +572,10 @@ transparent.</p>
 <span class="name">ax</span><span class="operator">.</span><span class="name">set_ylim</span><span class="punctuation">(</span><span class="literal number integer">0</span><span class="punctuation">,</span><span class="literal number integer">1</span><span class="punctuation">),</span> <span class="name">ax</span><span class="operator">.</span><span class="name">set_yticks</span><span class="punctuation">([])</span>
 </pre>
 <p>Now, we need to write the update function for our animation. We know that at
-each time step each ring should grow be more transparent while largest ring
-should be totally transparent and thus removed. Of course, we won't actually
-remove the largest ring but re-use it to set a new ring at a new random
-position, with nominal size and color. Hence, we keep the number of ring
+each time step each ring should grow and become more transparent while the
+largest ring should be totally transparent and thus removed. Of course, we won't
+actually remove the largest ring but re-use it to set a new ring at a new random
+position, with nominal size and color. Hence, we keep the number of rings
 constant.</p>
 <a class="reference external image-reference" href="scripts/rain-dynamic.py"><img alt="figures/rain.gif" class="align-right" src="figures/rain.gif" /></a>
 <pre class="code python literal-block">
@@ -606,7 +605,7 @@ constant.</p>
 <p>Last step is to tell matplotlib to use this function as an update function for
 the animation and display the result or save it as a movie:</p>
 <pre class="code python literal-block">
-<span class="name">animation</span> <span class="operator">=</span> <span class="name">FuncAnimation</span><span class="punctuation">(</span><span class="name">fig</span><span class="punctuation">,</span> <span class="name">update</span><span class="punctuation">,</span> <span class="name">interval</span><span class="operator">=</span><span class="literal number integer">10</span><span class="punctuation">,</span> <span class="name">blit</span><span class="operator">=</span><span class="name builtin pseudo">True</span><span class="punctuation">,</span> <span class="name">frames</span><span class="operator">=</span><span class="literal number integer">200</span><span class="punctuation">)</span>
+<span class="name">animation</span> <span class="operator">=</span> <span class="name">FuncAnimation</span><span class="punctuation">(</span><span class="name">fig</span><span class="punctuation">,</span> <span class="name">update</span><span class="punctuation">,</span> <span class="name">interval</span><span class="operator">=</span><span class="literal number integer">10</span><span class="punctuation">,</span> <span class="name">blit</span><span class="operator">=</span><span class="keyword constant">True</span><span class="punctuation">,</span> <span class="name">frames</span><span class="operator">=</span><span class="literal number integer">200</span><span class="punctuation">)</span>
 <span class="comment single"># animation.save('rain.gif', writer='imagemagick', fps=30, dpi=40)</span>
 <span class="name">plt</span><span class="operator">.</span><span class="name">show</span><span class="punctuation">()</span>
 </pre>
@@ -616,14 +615,14 @@ the animation and display the result or save it as a movie:</p>
 <p>We'll now use the rain animation to visualize earthquakes on the planet from
 the last 30 days. The USGS Earthquake Hazards Program is part of the National
 Earthquake Hazards Reduction Program (NEHRP) and provides several data on their
-<a class="reference external" href="http://earthquake.usgs.gov">website</a>. Those data are sorted according to
+<a class="reference external" href="https://earthquake.usgs.gov">website</a>. Those data are sorted according to
 earthquakes magnitude, ranging from significant only down to all earthquakes,
 major or minor. You would be surprised by the number of minor earthquakes
 happening every hour on the planet. Since this would represent too much data
 for us, we'll stick to earthquakes with magnitude &gt; 4.5. At the time of writing,
 this already represent more than 300 earthquakes in the last 30 days.</p>
 <p>First step is to read and convert data. We'll use the <cite>urllib</cite> library that
-allows to open and read remote data. Data on the website use the <cite>CSV</cite> format
+allows us to open and read remote data. Data on the website use the <cite>CSV</cite> format
 whose content is given by the first line:</p>
 <pre class="literal-block">
 time,latitude,longitude,depth,mag,magType,nst,gap,dmin,rms,net,id,updated,place,type
@@ -634,10 +633,9 @@ time,latitude,longitude,depth,mag,magType,nst,gap,dmin,rms,net,id,updated,place,
 time of event (ok, that's bad, feel free to send me a PR).</p>
 <pre class="code python literal-block">
 <span class="keyword namespace">import</span> <span class="name namespace">urllib</span>
-<span class="keyword namespace">from</span> <span class="name namespace">mpl_toolkits.basemap</span> <span class="keyword namespace">import</span> <span class="name">Basemap</span>
 
-<span class="comment single"># -&gt; http://earthquake.usgs.gov/earthquakes/feed/v1.0/csv.php</span>
-<span class="name">feed</span> <span class="operator">=</span> <span class="literal string double">&quot;http://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/&quot;</span>
+<span class="comment single"># -&gt; https://earthquake.usgs.gov/earthquakes/feed/v1.0/csv.php</span>
+<span class="name">feed</span> <span class="operator">=</span> <span class="literal string double">&quot;https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/&quot;</span>
 
 <span class="comment single"># Significant earthquakes in the last 30 days</span>
 <span class="comment single"># url = urllib.request.urlopen(feed + &quot;significant_month.csv&quot;)</span>
@@ -653,41 +651,52 @@ time of event (ok, that's bad, feel free to send me a PR).</p>
 
 <span class="comment single"># Reading and storage of data</span>
 <span class="name">data</span> <span class="operator">=</span> <span class="name">url</span><span class="operator">.</span><span class="name">read</span><span class="punctuation">()</span>
-<span class="name">data</span> <span class="operator">=</span> <span class="name">data</span><span class="operator">.</span><span class="name">split</span><span class="punctuation">(</span><span class="name">b</span><span class="literal string single">'</span><span class="literal string escape">\n</span><span class="literal string single">'</span><span class="punctuation">)[</span><span class="operator">+</span><span class="literal number integer">1</span><span class="punctuation">:</span><span class="operator">-</span><span class="literal number integer">1</span><span class="punctuation">]</span>
+<span class="name">data</span> <span class="operator">=</span> <span class="name">data</span><span class="operator">.</span><span class="name">split</span><span class="punctuation">(</span><span class="literal string affix">b</span><span class="literal string single">'</span><span class="literal string escape">\n</span><span class="literal string single">'</span><span class="punctuation">)[</span><span class="operator">+</span><span class="literal number integer">1</span><span class="punctuation">:</span><span class="operator">-</span><span class="literal number integer">1</span><span class="punctuation">]</span>
 <span class="name">E</span> <span class="operator">=</span> <span class="name">np</span><span class="operator">.</span><span class="name">zeros</span><span class="punctuation">(</span><span class="name builtin">len</span><span class="punctuation">(</span><span class="name">data</span><span class="punctuation">),</span> <span class="name">dtype</span><span class="operator">=</span><span class="punctuation">[(</span><span class="literal string single">'position'</span><span class="punctuation">,</span>  <span class="name builtin">float</span><span class="punctuation">,</span> <span class="literal number integer">2</span><span class="punctuation">),</span>
-                               <span class="punctuation">(</span><span class="literal string single">'magnitude'</span><span class="punctuation">,</span> <span class="name builtin">float</span><span class="punctuation">,</span> <span class="literal number integer">1</span><span class="punctuation">)])</span>
+                               <span class="punctuation">(</span><span class="literal string single">'magnitude'</span><span class="punctuation">,</span> <span class="name builtin">float</span><span class="punctuation">)])</span>
 
 <span class="keyword">for</span> <span class="name">i</span> <span class="operator word">in</span> <span class="name builtin">range</span><span class="punctuation">(</span><span class="name builtin">len</span><span class="punctuation">(</span><span class="name">data</span><span class="punctuation">)):</span>
-    <span class="name">row</span> <span class="operator">=</span> <span class="name">data</span><span class="punctuation">[</span><span class="name">i</span><span class="punctuation">]</span><span class="operator">.</span><span class="name">split</span><span class="punctuation">(</span><span class="literal string single">','</span><span class="punctuation">)</span>
+    <span class="name">row</span> <span class="operator">=</span> <span class="name">data</span><span class="punctuation">[</span><span class="name">i</span><span class="punctuation">]</span><span class="operator">.</span><span class="name">split</span><span class="punctuation">(</span><span class="literal string affix">b</span><span class="literal string single">','</span><span class="punctuation">)</span>
     <span class="name">E</span><span class="punctuation">[</span><span class="literal string single">'position'</span><span class="punctuation">][</span><span class="name">i</span><span class="punctuation">]</span> <span class="operator">=</span> <span class="name builtin">float</span><span class="punctuation">(</span><span class="name">row</span><span class="punctuation">[</span><span class="literal number integer">2</span><span class="punctuation">]),</span><span class="name builtin">float</span><span class="punctuation">(</span><span class="name">row</span><span class="punctuation">[</span><span class="literal number integer">1</span><span class="punctuation">])</span>
     <span class="name">E</span><span class="punctuation">[</span><span class="literal string single">'magnitude'</span><span class="punctuation">][</span><span class="name">i</span><span class="punctuation">]</span> <span class="operator">=</span> <span class="name builtin">float</span><span class="punctuation">(</span><span class="name">row</span><span class="punctuation">[</span><span class="literal number integer">4</span><span class="punctuation">])</span>
 </pre>
-<p>Now, we need to draw earth on a figure to show precisely where the earthquake
+<p>Now, we need to draw the earth on a figure to show precisely where the earthquake
 center is and to translate latitude/longitude in some coordinates matplotlib
-can handle. Fortunately, there is the <a class="reference external" href="http://matplotlib.org/basemap/">basemap</a> project (that tends to be replaced by the
-more complete <a class="reference external" href="http://scitools.org.uk/cartopy/">cartopy</a>) that is really
+can handle. Fortunately, there is the <a class="reference external" href="https://matplotlib.org/basemap/">basemap</a> project (which is now deprecated in favor
+of the <a class="reference external" href="https://scitools.org.uk/cartopy/docs/latest/">cartopy</a> project) that is really
 simple to install and to use. First step is to define a projection to draw the
 earth onto a screen (there exists many different projections) and we'll stick
 to the <cite>mill</cite> projection which is rather standard for non-specialist like me.</p>
 <pre class="code python literal-block">
+<span class="keyword namespace">from</span> <span class="name namespace">mpl_toolkits.basemap</span> <span class="keyword namespace">import</span> <span class="name">Basemap</span>
 <span class="name">fig</span> <span class="operator">=</span> <span class="name">plt</span><span class="operator">.</span><span class="name">figure</span><span class="punctuation">(</span><span class="name">figsize</span><span class="operator">=</span><span class="punctuation">(</span><span class="literal number integer">14</span><span class="punctuation">,</span><span class="literal number integer">10</span><span class="punctuation">))</span>
 <span class="name">ax</span> <span class="operator">=</span> <span class="name">plt</span><span class="operator">.</span><span class="name">subplot</span><span class="punctuation">(</span><span class="literal number integer">1</span><span class="punctuation">,</span><span class="literal number integer">1</span><span class="punctuation">,</span><span class="literal number integer">1</span><span class="punctuation">)</span>
 
-<span class="name">earth</span> <span class="operator">=</span> <span class="name">Basemap</span><span class="punctuation">(</span><span class="name">projection</span><span class="operator">=</span><span class="literal string single">'mill'</span><span class="punctuation">)</span>
+<span class="name builtin">map</span> <span class="operator">=</span> <span class="name">Basemap</span><span class="punctuation">(</span><span class="name">projection</span><span class="operator">=</span><span class="literal string single">'mill'</span><span class="punctuation">)</span>
 </pre>
 <p>Next, we request to draw coastline and fill continents:</p>
 <pre class="code python literal-block">
-<span class="name">earth</span><span class="operator">.</span><span class="name">drawcoastlines</span><span class="punctuation">(</span><span class="name">color</span><span class="operator">=</span><span class="literal string single">'0.50'</span><span class="punctuation">,</span> <span class="name">linewidth</span><span class="operator">=</span><span class="literal number float">0.25</span><span class="punctuation">)</span>
-<span class="name">earth</span><span class="operator">.</span><span class="name">fillcontinents</span><span class="punctuation">(</span><span class="name">color</span><span class="operator">=</span><span class="literal string single">'0.95'</span><span class="punctuation">)</span>
+<span class="name builtin">map</span><span class="operator">.</span><span class="name">drawcoastlines</span><span class="punctuation">(</span><span class="name">color</span><span class="operator">=</span><span class="literal string single">'0.50'</span><span class="punctuation">,</span> <span class="name">linewidth</span><span class="operator">=</span><span class="literal number float">0.25</span><span class="punctuation">)</span>
+<span class="name builtin">map</span><span class="operator">.</span><span class="name">fillcontinents</span><span class="punctuation">(</span><span class="name">color</span><span class="operator">=</span><span class="literal string single">'0.95'</span><span class="punctuation">)</span>
 </pre>
-<p>The <cite>earth</cite> object will also be used to translate coordinate quite
-automatically. We are almost finished. Last step is to adapt the rain code and
-put some eye candy:</p>
+<p>For cartopy, the steps are quite similar:</p>
+<pre class="code python literal-block">
+<span class="keyword namespace">import</span> <span class="name namespace">cartopy</span>
+<span class="name">ax</span> <span class="operator">=</span> <span class="name">plt</span><span class="operator">.</span><span class="name">axes</span><span class="punctuation">(</span><span class="name">projection</span><span class="operator">=</span><span class="name">cartopy</span><span class="operator">.</span><span class="name">crs</span><span class="operator">.</span><span class="name">Miller</span><span class="punctuation">())</span>
+<span class="name">ax</span><span class="operator">.</span><span class="name">coastlines</span><span class="punctuation">(</span><span class="name">color</span><span class="operator">=</span><span class="literal string single">'0.50'</span><span class="punctuation">,</span> <span class="name">linewidth</span><span class="operator">=</span><span class="literal number float">0.25</span><span class="punctuation">)</span>
+<span class="name">ax</span><span class="operator">.</span><span class="name">add_feature</span><span class="punctuation">(</span><span class="name">cartopy</span><span class="operator">.</span><span class="name">feature</span><span class="operator">.</span><span class="name">LAND</span><span class="punctuation">,</span> <span class="name">color</span><span class="operator">=</span><span class="literal string single">'0.95'</span><span class="punctuation">)</span>
+<span class="name">ax</span><span class="operator">.</span><span class="name">set_global</span><span class="punctuation">()</span>
+<span class="name">trans</span> <span class="operator">=</span> <span class="name">cartopy</span><span class="operator">.</span><span class="name">crs</span><span class="operator">.</span><span class="name">PlateCarree</span><span class="punctuation">()</span>
+</pre>
+<p>We are almost finished. Last step is to adapt the rain code and
+put some eye candy. For basemap we use the map object to
+transform the coordinates whereas for cartopy we use the transform_point
+function of the chosen Miller projection:</p>
 <pre class="code python literal-block">
 <span class="name">P</span> <span class="operator">=</span> <span class="name">np</span><span class="operator">.</span><span class="name">zeros</span><span class="punctuation">(</span><span class="literal number integer">50</span><span class="punctuation">,</span> <span class="name">dtype</span><span class="operator">=</span><span class="punctuation">[(</span><span class="literal string single">'position'</span><span class="punctuation">,</span> <span class="name builtin">float</span><span class="punctuation">,</span> <span class="literal number integer">2</span><span class="punctuation">),</span>
-                         <span class="punctuation">(</span><span class="literal string single">'size'</span><span class="punctuation">,</span>     <span class="name builtin">float</span><span class="punctuation">,</span> <span class="literal number integer">1</span><span class="punctuation">),</span>
-                         <span class="punctuation">(</span><span class="literal string single">'growth'</span><span class="punctuation">,</span>   <span class="name builtin">float</span><span class="punctuation">,</span> <span class="literal number integer">1</span><span class="punctuation">),</span>
-                         <span class="punctuation">(</span><span class="literal string single">'color'</span><span class="punctuation">,</span>    <span class="name builtin">float</span><span class="punctuation">,</span> <span class="literal number integer">4</span><span class="punctuation">)])</span>
+                         <span class="punctuation">(</span><span class="literal string single">'size'</span><span class="punctuation">,</span>    <span class="name builtin">float</span><span class="punctuation">),</span>
+                         <span class="punctuation">(</span><span class="literal string single">'growth'</span><span class="punctuation">,</span>  <span class="name builtin">float</span><span class="punctuation">),</span>
+                         <span class="punctuation">(</span><span class="literal string single">'color'</span><span class="punctuation">,</span>   <span class="name builtin">float</span><span class="punctuation">,</span> <span class="literal number integer">4</span><span class="punctuation">)])</span>
 <span class="name">scat</span> <span class="operator">=</span> <span class="name">ax</span><span class="operator">.</span><span class="name">scatter</span><span class="punctuation">(</span><span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'position'</span><span class="punctuation">][:,</span><span class="literal number integer">0</span><span class="punctuation">],</span> <span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'position'</span><span class="punctuation">][:,</span><span class="literal number integer">1</span><span class="punctuation">],</span> <span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'size'</span><span class="punctuation">],</span> <span class="name">lw</span><span class="operator">=</span><span class="literal number float">0.5</span><span class="punctuation">,</span>
                   <span class="name">edgecolors</span> <span class="operator">=</span> <span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'color'</span><span class="punctuation">],</span> <span class="name">facecolors</span><span class="operator">=</span><span class="literal string single">'None'</span><span class="punctuation">,</span> <span class="name">zorder</span><span class="operator">=</span><span class="literal number integer">10</span><span class="punctuation">)</span>
 
@@ -699,7 +708,8 @@ put some eye candy:</p>
     <span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'size'</span><span class="punctuation">]</span> <span class="operator">+=</span> <span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'growth'</span><span class="punctuation">]</span>
 
     <span class="name">magnitude</span> <span class="operator">=</span> <span class="name">E</span><span class="punctuation">[</span><span class="literal string single">'magnitude'</span><span class="punctuation">][</span><span class="name">current</span><span class="punctuation">]</span>
-    <span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'position'</span><span class="punctuation">][</span><span class="name">i</span><span class="punctuation">]</span> <span class="operator">=</span> <span class="name">earth</span><span class="punctuation">(</span><span class="operator">*</span><span class="name">E</span><span class="punctuation">[</span><span class="literal string single">'position'</span><span class="punctuation">][</span><span class="name">current</span><span class="punctuation">])</span>
+    <span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'position'</span><span class="punctuation">][</span><span class="name">i</span><span class="punctuation">]</span> <span class="operator">=</span> <span class="name builtin">map</span><span class="punctuation">(</span><span class="operator">*</span><span class="name">E</span><span class="punctuation">[</span><span class="literal string single">'position'</span><span class="punctuation">][</span><span class="name">current</span><span class="punctuation">])</span> <span class="keyword">if</span> <span class="name">use_basemap</span> <span class="keyword">else</span> \
+        <span class="name">cartopy</span><span class="operator">.</span><span class="name">crs</span><span class="operator">.</span><span class="name">Miller</span><span class="punctuation">()</span><span class="operator">.</span><span class="name">transform_point</span><span class="punctuation">(</span><span class="operator">*</span><span class="name">E</span><span class="punctuation">[</span><span class="literal string single">'position'</span><span class="punctuation">][</span><span class="name">current</span><span class="punctuation">],</span> <span class="name">cartopy</span><span class="operator">.</span><span class="name">crs</span><span class="operator">.</span><span class="name">PlateCarree</span><span class="punctuation">())</span>
     <span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'size'</span><span class="punctuation">][</span><span class="name">i</span><span class="punctuation">]</span> <span class="operator">=</span> <span class="literal number integer">5</span>
     <span class="name">P</span><span class="punctuation">[</span><span class="literal string single">'growth'</span><span class="punctuation">][</span><span class="name">i</span><span class="punctuation">]</span><span class="operator">=</span> <span class="name">np</span><span class="operator">.</span><span class="name">exp</span><span class="punctuation">(</span><span class="name">magnitude</span><span class="punctuation">)</span> <span class="operator">*</span> <span class="literal number float">0.1</span>
 
@@ -714,7 +724,7 @@ put some eye candy:</p>
     <span class="keyword">return</span> <span class="name">scat</span><span class="punctuation">,</span>
 
 
-<span class="name">animation</span> <span class="operator">=</span> <span class="name">FuncAnimation</span><span class="punctuation">(</span><span class="name">fig</span><span class="punctuation">,</span> <span class="name">update</span><span class="punctuation">,</span> <span class="name">interval</span><span class="operator">=</span><span class="literal number integer">10</span><span class="punctuation">)</span>
+<span class="name">animation</span> <span class="operator">=</span> <span class="name">FuncAnimation</span><span class="punctuation">(</span><span class="name">fig</span><span class="punctuation">,</span> <span class="name">update</span><span class="punctuation">,</span> <span class="name">interval</span><span class="operator">=</span><span class="literal number integer">10</span><span class="punctuation">,</span> <span class="name">blit</span><span class="operator">=</span><span class="keyword constant">True</span><span class="punctuation">)</span>
 <span class="name">plt</span><span class="operator">.</span><span class="name">show</span><span class="punctuation">()</span>
 </pre>
 <p>If everything went well, you should obtain something like this (with animation):</p>
@@ -722,7 +732,7 @@ put some eye candy:</p>
 </div>
 </div>
 <div class="section" id="other-types-of-plots">
-<h1><a class="toc-backref" href="#id8">Other Types of Plots</a></h1>
+<h1><a class="toc-backref" href="#id9">Other Types of Plots</a></h1>
 <a class="reference internal image-reference" href="#regular-plots"><img alt="figures/plot.png" src="figures/plot.png" /></a>
 <a class="reference internal image-reference" href="#scatter-plots"><img alt="figures/scatter.png" src="figures/scatter.png" /></a>
 <a class="reference internal image-reference" href="#bar-plots"><img alt="figures/bar.png" src="figures/bar.png" /></a>
@@ -738,13 +748,13 @@ put some eye candy:</p>
 <div class="section" id="regular-plots">
 <h2>Regular Plots</h2>
 <a class="reference external image-reference" href="scripts/plot_ex.py"><img alt="figures/plot_ex.png" class="align-right" src="figures/plot_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
 <p class="last">You need to use the <a class="reference external" href="http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.fill_between">fill_between</a>
 command.</p>
 </div>
 <p>Starting from the code below, try to reproduce the graphic on the right taking
-care of filled areas:</p>
+care of filled areas.</p>
 <pre class="literal-block">
 import numpy as np
 import matplotlib.pyplot as plt
@@ -762,7 +772,7 @@ plt.show()
 <div class="section" id="scatter-plots">
 <h2>Scatter Plots</h2>
 <a class="reference external image-reference" href="scripts/scatter_ex.py"><img alt="figures/scatter_ex.png" class="align-right" src="figures/scatter_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
 <p class="last">Color is given by angle of (X,Y).</p>
 </div>
@@ -784,7 +794,7 @@ plt.show()
 <div class="section" id="bar-plots">
 <h2>Bar Plots</h2>
 <a class="reference external image-reference" href="scripts/bar_ex.py"><img alt="figures/bar_ex.png" class="align-right" src="figures/bar_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
 <p class="last">You need to take care of text alignment.</p>
 </div>
@@ -813,7 +823,7 @@ plt.show()
 <div class="section" id="contour-plots">
 <h2>Contour Plots</h2>
 <a class="reference external image-reference" href="scripts/contour_ex.py"><img alt="figures/contour_ex.png" class="align-right" src="figures/contour_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
 <p class="last">You need to use the <a class="reference external" href="http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.clabel">clabel</a>
 command.</p>
@@ -840,10 +850,10 @@ plt.show()
 <div class="section" id="imshow">
 <h2>Imshow</h2>
 <a class="reference external image-reference" href="scripts/imshow_ex.py"><img alt="figures/imshow_ex.png" class="align-right" src="figures/imshow_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
 <p class="last">You need to take care of the <tt class="docutils literal">origin</tt> of the image in the imshow command and
-use a <a class="reference external" href="http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.colorbar">colorbar</a></p>
+use a <a class="reference external" href="http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.colorbar">colorbar</a>.</p>
 </div>
 <p>Starting from the code below, try to reproduce the graphic on the right taking
 care of colormap, image interpolation and origin.</p>
@@ -865,7 +875,7 @@ plt.show()
 <div class="section" id="pie-charts">
 <h2>Pie Charts</h2>
 <a class="reference external image-reference" href="scripts/pie_ex.py"><img alt="figures/pie_ex.png" class="align-right" src="figures/pie_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
 <p class="last">You need to modify Z.</p>
 </div>
@@ -885,7 +895,7 @@ plt.show()
 <div class="section" id="quiver-plots">
 <h2>Quiver Plots</h2>
 <a class="reference external image-reference" href="scripts/quiver_ex.py"><img alt="figures/quiver_ex.png" class="align-right" src="figures/quiver_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
 <p class="last">You need to draw arrows twice.</p>
 </div>
@@ -924,7 +934,7 @@ plt.show()
 <div class="section" id="multi-plots">
 <h2>Multi Plots</h2>
 <a class="reference external image-reference" href="scripts/multiplot_ex.py"><img alt="figures/multiplot_ex.png" class="align-right" src="figures/multiplot_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
 <p class="last">You can use several subplots with different partition.</p>
 </div>
@@ -944,9 +954,9 @@ plt.show()
 <div class="section" id="polar-axis">
 <h2>Polar Axis</h2>
 <a class="reference external image-reference" href="scripts/polar_ex.py"><img alt="figures/polar_ex.png" class="align-right" src="figures/polar_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
-<p class="last">You only need to modify the <tt class="docutils literal">axes</tt> line</p>
+<p class="last">You only need to modify the <tt class="docutils literal">axes</tt> line.</p>
 </div>
 <p>Starting from the code below, try to reproduce the graphic on the right.</p>
 <pre class="literal-block">
@@ -972,9 +982,9 @@ plt.show()
 <div class="section" id="d-plots">
 <h2>3D Plots</h2>
 <a class="reference external image-reference" href="scripts/plot3d_ex.py"><img alt="figures/plot3d_ex.png" class="align-right" src="figures/plot3d_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
-<p class="last">You need to use <a class="reference external" href="http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.contourf">contourf</a></p>
+<p class="last">You need to use <a class="reference external" href="http://matplotlib.sourceforge.net/api/pyplot_api.html#matplotlib.pyplot.contourf">contourf</a>.</p>
 </div>
 <p>Starting from the code below, try to reproduce the graphic on the right.</p>
 <pre class="literal-block">
@@ -999,16 +1009,16 @@ plt.show()
 <div class="section" id="text">
 <h2>Text</h2>
 <a class="reference external image-reference" href="scripts/text_ex.py"><img alt="figures/text_ex.png" class="align-right" src="figures/text_ex.png" /></a>
-<div class="admonition-hints admonition">
+<div class="admonition admonition-hints">
 <p class="first admonition-title">Hints</p>
 <p class="last">Have a look at the <a class="reference external" href="http://matplotlib.sourceforge.net/examples/api/logo2.html">matplotlib logo</a>.</p>
 </div>
-<p>Try to do the same from scratch !</p>
+<p>Try to do the same from scratch!</p>
 <p>Click on figure for solution.</p>
 </div>
 </div>
 <div class="section" id="beyond-this-tutorial">
-<h1><a class="toc-backref" href="#id9">Beyond this tutorial</a></h1>
+<h1><a class="toc-backref" href="#id10">Beyond this tutorial</a></h1>
 <p>Matplotlib benefits from extensive documentation as well as a large
 community of users and developpers. Here are some links of interest:</p>
 <div class="section" id="tutorials">
@@ -1126,11 +1136,11 @@ technical.</p>
 </div>
 </div>
 <div class="section" id="quick-references">
-<h1><a class="toc-backref" href="#id10">Quick references</a></h1>
+<h1><a class="toc-backref" href="#id11">Quick references</a></h1>
 <p>Here is a set of tables that show main properties and styles.</p>
 <div class="section" id="line-properties">
 <h2>Line properties</h2>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="20%" />
 <col width="30%" />
@@ -1217,7 +1227,7 @@ technical.</p>
 </div>
 <div class="section" id="line-styles">
 <h2>Line styles</h2>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="16%" />
 <col width="32%" />
@@ -1360,7 +1370,7 @@ technical.</p>
 </div>
 <div class="section" id="markers">
 <h2>Markers</h2>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="16%" />
 <col width="32%" />
@@ -1540,11 +1550,11 @@ technical.</p>
 <h2>Colormaps</h2>
 <p>All colormaps can be reversed by appending <tt class="docutils literal">_r</tt>. For instance, <tt class="docutils literal">gray_r</tt> is
 the reverse of <tt class="docutils literal">gray</tt>.</p>
-<p>If you want to know more about colormaps, checks <a class="reference external" href="https://gist.github.com/2719900">Documenting the matplotlib
+<p>If you want to know more about colormaps, see <a class="reference external" href="https://gist.github.com/2719900">Documenting the matplotlib
 colormaps</a>.</p>
 <div class="section" id="base">
 <h3>Base</h3>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="30%" />
 <col width="70%" />
@@ -1620,7 +1630,7 @@ colormaps</a>.</p>
 </div>
 <div class="section" id="gist">
 <h3>GIST</h3>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="30%" />
 <col width="70%" />
@@ -1662,9 +1672,9 @@ colormaps</a>.</p>
 </tbody>
 </table>
 </div>
-<div class="section" id="sequential">
+<div class="section" id="diverging">
 <h3>Diverging</h3>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="30%" />
 <col width="70%" />
@@ -1714,9 +1724,9 @@ colormaps</a>.</p>
 </tbody>
 </table>
 </div>
-<div class="section" id="diverging">
+<div class="section" id="sequential">
 <h3>Sequential</h3>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="30%" />
 <col width="70%" />
@@ -1804,7 +1814,7 @@ colormaps</a>.</p>
 </div>
 <div class="section" id="qualitative">
 <h3>Qualitative</h3>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="30%" />
 <col width="70%" />
@@ -1852,7 +1862,7 @@ colormaps</a>.</p>
 </div>
 <div class="section" id="miscellaneous">
 <h3>Miscellaneous</h3>
-<table border="1" class="docutils">
+<table border="1" class="colwidths-given docutils">
 <colgroup>
 <col width="30%" />
 <col width="70%" />

--- a/scripts/check-installation.py
+++ b/scripts/check-installation.py
@@ -37,23 +37,30 @@ if LooseVersion(mpl.__version__) < LooseVersion("1.5"):
 else:
     print("ok")
 
-# Check for basemap
+# Check for basemap or cartopy
 try:
-    import mpl_toolkits.basemap as basemap 
+    import mpl_toolkits.basemap as basemap
+    check_for_cartopy = False
 except:
-    print("This tutorial requires basemap\n")
-    sys.exit()
-print("Check for basemap: ", end="")
-if LooseVersion(basemap.__version__) < LooseVersion("1.0"):
-    print("basemape is too old (< 1.0) \n")
-    sys.exit()
+    check_for_cartopy = True
 else:
-    print("ok")
-        
-# Check for urllib
-try:
-    import urllib
-except:
-    print("This tutorial requires urllib")
-else:
-    print("Check for urllib: ok")
+    print("Check for basemap: ", end="")
+    if LooseVersion(basemap.__version__) < LooseVersion("1.0"):
+        print("basemap is too old (< 1.0) \n")
+        sys.exit()
+    else:
+        print("ok")
+
+if check_for_cartopy:
+    try:
+        import cartopy
+    except:
+        print("This tutorial requires either basemap or cartopy\n")
+        sys.exit()
+
+    print("Check for cartopy: ", end="")
+    if LooseVersion(cartopy.__version__) < LooseVersion("0.15"):
+        print("cartopy is too old (< 0.15) \n")
+        sys.exit()
+    else:
+        print("ok")


### PR DESCRIPTION
Update earthquakes example

- add `cartopy` as alternative to deprecated `basemap`
- prevent numpy warning "Passing (type, 1) or '1type' as a synonym of type is deprecated"
- while updating `check-installation.py` I also removed the check for `urllib` as it's now included in the standard python distribution

Using cartopy of course results in visually the same plot:
![earthquakes_cartopy](https://user-images.githubusercontent.com/19879328/141368908-06a30ef0-9df8-4ddd-bcc7-541c52a5262a.png)

Also I updated the html file to again correspond to the rst file using the make file in the repo. This includes not only the current changes to README.rst but also older changes, e.g. #10 that were made to the rst file only (sorry for the additional changes due using the current version 0.17.1 of docutils instead of 0.12).